### PR TITLE
Require association to be specified when opening a config

### DIFF
--- a/autotests/kconfig_compiler/kconfigcompiler_test_signals.cpp
+++ b/autotests/kconfig_compiler/kconfigcompiler_test_signals.cpp
@@ -49,8 +49,10 @@ void KConfigCompiler_Test_Signals::initTestCase()
 
     SignalsTestSingleton::instance(QFileInfo(*tempFile1).absoluteFilePath());
     SignalsTestSingletonDpointer::instance(QFileInfo(*tempFile2).absoluteFilePath());
-    noSingleton = new SignalsTestNoSingleton(KSharedConfig::openConfig(KConfig::ConfigAssociation::KdeApp, QFileInfo(*tempFile3).absoluteFilePath(), KConfig::SimpleConfig));
-    noSingletonDpointer = new SignalsTestNoSingletonDpointer(KSharedConfig::openConfig(KConfig::ConfigAssociation::KdeApp, QFileInfo(*tempFile4).absoluteFilePath(), KConfig::SimpleConfig));
+    noSingleton = new SignalsTestNoSingleton(
+        KSharedConfig::openConfig(KConfig::ConfigAssociation::KdeApp, QFileInfo(*tempFile3).absoluteFilePath(), KConfig::SimpleConfig));
+    noSingletonDpointer = new SignalsTestNoSingletonDpointer(
+        KSharedConfig::openConfig(KConfig::ConfigAssociation::KdeApp, QFileInfo(*tempFile4).absoluteFilePath(), KConfig::SimpleConfig));
     SignalsTestSingletonItemAccessors::instance(QFileInfo(*tempFile5).absoluteFilePath());
 }
 

--- a/autotests/kconfig_compiler/kconfigcompiler_test_signals.cpp
+++ b/autotests/kconfig_compiler/kconfigcompiler_test_signals.cpp
@@ -49,8 +49,8 @@ void KConfigCompiler_Test_Signals::initTestCase()
 
     SignalsTestSingleton::instance(QFileInfo(*tempFile1).absoluteFilePath());
     SignalsTestSingletonDpointer::instance(QFileInfo(*tempFile2).absoluteFilePath());
-    noSingleton = new SignalsTestNoSingleton(KSharedConfig::openConfig(QFileInfo(*tempFile3).absoluteFilePath(), KConfig::SimpleConfig));
-    noSingletonDpointer = new SignalsTestNoSingletonDpointer(KSharedConfig::openConfig(QFileInfo(*tempFile4).absoluteFilePath(), KConfig::SimpleConfig));
+    noSingleton = new SignalsTestNoSingleton(KSharedConfig::openConfig(KConfig::ConfigAssociation::KdeApp, QFileInfo(*tempFile3).absoluteFilePath(), KConfig::SimpleConfig));
+    noSingletonDpointer = new SignalsTestNoSingletonDpointer(KSharedConfig::openConfig(KConfig::ConfigAssociation::KdeApp, QFileInfo(*tempFile4).absoluteFilePath(), KConfig::SimpleConfig));
     SignalsTestSingletonItemAccessors::instance(QFileInfo(*tempFile5).absoluteFilePath());
 }
 

--- a/autotests/kconfig_compiler/myprefs.h
+++ b/autotests/kconfig_compiler/myprefs.h
@@ -7,7 +7,7 @@ class MyPrefs : public KConfigSkeleton
 {
 public:
     MyPrefs(const QString &a)
-        : KConfigSkeleton(a)
+        : KConfigSkeleton(KConfig::ConfigAssociation::KdeApp, a)
     {
     }
 };

--- a/autotests/kconfig_compiler/test1.cpp.ref
+++ b/autotests/kconfig_compiler/test1.cpp.ref
@@ -4,7 +4,7 @@
 #include "test1.h"
 
 Test1::Test1( const QString & transport, const QString & folder, QObject *parent )
-  : KConfigSkeleton( QStringLiteral( "examplerc" ) )
+  : KConfigSkeleton(KConfig::ConfigAssociation::KdeApp, QStringLiteral( "examplerc" ) )
   , mParamtransport(transport)
   , mParamfolder(folder)
 {

--- a/autotests/kconfig_compiler/test10.cpp.ref
+++ b/autotests/kconfig_compiler/test10.cpp.ref
@@ -27,7 +27,7 @@ Test10 *Test10::self()
 }
 
 Test10::Test10( )
-  : KConfigSkeleton( QStringLiteral( "test10rc" ) )
+  : KConfigSkeleton(KConfig::ConfigAssociation::KdeApp, QStringLiteral( "test10rc" ) )
 {
   Q_ASSERT(!s_globalTest10()->q);
   s_globalTest10()->q = this;

--- a/autotests/kconfig_compiler/test12.cpp.ref
+++ b/autotests/kconfig_compiler/test12.cpp.ref
@@ -4,7 +4,7 @@
 #include "test12.h"
 
 Test12::Test12( )
-  : KConfigSkeleton( QStringLiteral( "muondatasourcesrc" ) )
+  : KConfigSkeleton( KConfig::ConfigAssociation::KdeApp, QStringLiteral( "muondatasourcesrc" ) )
 {
   setCurrentGroup( QStringLiteral( "muon" ) );
 

--- a/autotests/kconfig_compiler/test13.cpp.ref
+++ b/autotests/kconfig_compiler/test13.cpp.ref
@@ -4,7 +4,7 @@
 #include "test13.h"
 
 Test13::Test13( )
-  : KConfigSkeleton( QStringLiteral( "muondatasourcesrc" ) )
+  : KConfigSkeleton( KConfig::ConfigAssociation::KdeApp, QStringLiteral( "muondatasourcesrc" ) )
 {
   KConfigCompilerSignallingItem::NotifyFunction notifyFunction = static_cast<KConfigCompilerSignallingItem::NotifyFunction>(&Test13::itemChanged);
 

--- a/autotests/kconfig_compiler/test1main.cpp
+++ b/autotests/kconfig_compiler/test1main.cpp
@@ -14,7 +14,7 @@ int main(int argc, char **argv)
     Q_UNUSED(app);
 
     {
-        KConfig initialConfig(QStringLiteral("examplerc"));
+        KConfig initialConfig(KConfig::ConfigAssociation::KdeApp, QStringLiteral("examplerc"));
         KConfigGroup group = initialConfig.group(QStringLiteral("MyOptions"));
         group.writeEntry(QStringLiteral("MyString"), QStringLiteral("The String"));
     }

--- a/autotests/kconfig_compiler/test3.cpp.ref
+++ b/autotests/kconfig_compiler/test3.cpp.ref
@@ -6,7 +6,7 @@
 using namespace TestNameSpace;
 
 Test3::Test3( )
-  : KConfigSkeleton( QStringLiteral( "test3rc" ) )
+  : KConfigSkeleton( KConfig::ConfigAssociation::KdeApp, QStringLiteral( "test3rc" ) )
 {
   setCurrentGroup( QStringLiteral( "General" ) );
 

--- a/autotests/kconfig_compiler/test3a.cpp.ref
+++ b/autotests/kconfig_compiler/test3a.cpp.ref
@@ -6,7 +6,7 @@
 using namespace TestNameSpace::InnerNameSpace;
 
 Test3a::Test3a( )
-  : KConfigSkeleton( QStringLiteral( "test3arc" ) )
+  : KConfigSkeleton( KConfig::ConfigAssociation::KdeApp, QStringLiteral( "test3arc" ) )
 {
   setCurrentGroup( QStringLiteral( "General" ) );
 

--- a/autotests/kconfig_compiler/test4.cpp.ref
+++ b/autotests/kconfig_compiler/test4.cpp.ref
@@ -29,7 +29,7 @@ Test4 *Test4::self()
 const char* const Test4::EnumButton::enumToString[] = { "right", "mid", "left" };
 
 Test4::Test4( )
-  : KConfigSkeleton( QStringLiteral( "test4rc" ) )
+  : KConfigSkeleton( KConfig::ConfigAssociation::KdeApp, QStringLiteral( "test4rc" ) )
 {
   Q_ASSERT(!s_globalTest4()->q);
   s_globalTest4()->q = this;

--- a/autotests/kconfig_compiler/test4main.cpp
+++ b/autotests/kconfig_compiler/test4main.cpp
@@ -14,7 +14,7 @@ int main(int argc, char **argv)
     QGuiApplication app(argc, argv);
     Q_UNUSED(app);
     {
-        KConfig initialConfig(QStringLiteral("test4rc"));
+        KConfig initialConfig(KConfig::ConfigAssociation::KdeApp, QStringLiteral("test4rc"));
         KConfigGroup group = initialConfig.group(QStringLiteral("Foo"));
         group.writeEntry(QStringLiteral("foo bar"), QStringLiteral("Value"));
     }

--- a/autotests/kconfig_compiler/test5.cpp.ref
+++ b/autotests/kconfig_compiler/test5.cpp.ref
@@ -29,7 +29,7 @@ Test5 *Test5::self()
 const char* const Test5::EnumButtonToString[] = { "right", "mid", "left" };
 
 Test5::Test5( QObject *parent )
-  : KConfigSkeleton( QStringLiteral( "test4rc" ) )
+  : KConfigSkeleton( KConfig::ConfigAssociation::KdeApp, QStringLiteral( "test4rc" ) )
 {
   setParent(parent);
   Q_ASSERT(!s_globalTest5()->q);

--- a/autotests/kconfig_compiler/test6.cpp.ref
+++ b/autotests/kconfig_compiler/test6.cpp.ref
@@ -4,7 +4,7 @@
 #include "test6.h"
 
 Test6::Test6( const QString & Number )
-  : KConfigSkeleton( QStringLiteral( "test4rc" ) )
+  : KConfigSkeleton( KConfig::ConfigAssociation::KdeApp, QStringLiteral( "test4rc" ) )
   , mParamNumber(Number)
 {
   setCurrentGroup( QStringLiteral( "Foo" ) );

--- a/autotests/kconfig_compiler/test7.cpp.ref
+++ b/autotests/kconfig_compiler/test7.cpp.ref
@@ -4,7 +4,7 @@
 #include "test7.h"
 
 Test7::Test7( int Number )
-  : KConfigSkeleton( QStringLiteral( "test7rc" ) )
+  : KConfigSkeleton( KConfig::ConfigAssociation::KdeApp, QStringLiteral( "test7rc" ) )
   , mParamNumber(Number)
 {
   setCurrentGroup( QStringLiteral( "Foo" ) );

--- a/autotests/kconfig_compiler/test8a.cpp.ref
+++ b/autotests/kconfig_compiler/test8a.cpp.ref
@@ -4,7 +4,7 @@
 #include "test8a.h"
 
 Test8a::Test8a( KSharedConfig::Ptr config, QObject *parent )
-  : KConfigSkeleton( std::move( config ) )
+  : KConfigSkeleton( KConfig::ConfigAssociation::KdeApp, std::move( config ) )
 {
   setParent(parent);
   setCurrentGroup( QStringLiteral( "Group" ) );

--- a/autotests/kconfig_compiler/test8main.cpp
+++ b/autotests/kconfig_compiler/test8main.cpp
@@ -13,10 +13,10 @@ int main(int argc, char **argv)
 {
     QGuiApplication app(argc, argv);
     Q_UNUSED(app);
-    Test8a *config1 = new Test8a(KSharedConfig::openConfig(QString()));
+    Test8a *config1 = new Test8a(KSharedConfig::openConfig(KConfig::ConfigAssociation::KdeApp, QString()));
     Test8a *config2 = new Test8a();
     Test8b::self();
-    Test8c::instance(KSharedConfig::openConfig(QString()));
+    Test8c::instance(KSharedConfig::openConfig(KConfig::ConfigAssociation::KdeApp, QString()));
     Test8c::self();
     delete config1;
     delete config2;

--- a/autotests/kconfigguitest.cpp
+++ b/autotests/kconfigguitest.cpp
@@ -32,10 +32,10 @@ void KConfigTest::initTestCase()
     QStandardPaths::setTestModeEnabled(true);
 
     // cheat the linker on windows to link against kconfiggui
-    KConfigSkeleton foo;
+    KConfigSkeleton foo(KConfig::ConfigAssociation::KdeApp);
     Q_UNUSED(foo);
 
-    KConfig sc(QStringLiteral("kconfigtest"));
+    KConfig sc(KConfig::ConfigAssociation::KdeApp, QStringLiteral("kconfigtest"));
 
     KConfigGroup cg(&sc, "ComplexTypes");
     cg.writeEntry("colorEntry1", s_color_entry1);
@@ -45,7 +45,7 @@ void KConfigTest::initTestCase()
     cg.writeEntry("fontEntry", fontEntry());
     QVERIFY(sc.sync());
 
-    KConfig sc1(QStringLiteral("kdebugrc"));
+    KConfig sc1(KConfig::ConfigAssociation::KdeApp, QStringLiteral("kdebugrc"));
     KConfigGroup sg0(&sc1, "0");
     sg0.writeEntry("AbortFatal", false);
     sg0.writeEntry("WarnOutput", 0);
@@ -74,7 +74,7 @@ void KConfigTest::cleanupTestCase()
 
 void KConfigTest::testComplex()
 {
-    KConfig sc2(QStringLiteral("kconfigtest"));
+    KConfig sc2(KConfig::ConfigAssociation::KdeApp, QStringLiteral("kconfigtest"));
     KConfigGroup sc3(&sc2, "ComplexTypes");
 
     QCOMPARE(QVariant(sc3.readEntry("colorEntry1", QColor(Qt::black))).toString(), QVariant(s_color_entry1).toString());
@@ -91,7 +91,7 @@ void KConfigTest::testComplex()
 
 void KConfigTest::testInvalid()
 {
-    KConfig sc(QStringLiteral("kconfigtest"));
+    KConfig sc(KConfig::ConfigAssociation::KdeApp, QStringLiteral("kconfigtest"));
 
     // all of these should print a message to the kdebug.dbg file
     KConfigGroup sc3(&sc, "InvalidTypes");

--- a/autotests/kconfigloadertest.cpp
+++ b/autotests/kconfigloadertest.cpp
@@ -27,7 +27,7 @@ void ConfigLoaderTest::init()
 {
     QString fileName = s_testName + QLatin1String(".xml");
     configFile = new QFile(QFINDTESTDATA(QString::fromLatin1("/") + fileName));
-    cl = new KConfigLoader(configFile->fileName(), configFile);
+    cl = new KConfigLoader(KConfig::ConfigAssociation::KdeApp, configFile->fileName(), configFile);
 }
 
 void ConfigLoaderTest::cleanup()

--- a/autotests/kconfigskeletontest.cpp
+++ b/autotests/kconfigskeletontest.cpp
@@ -40,7 +40,7 @@ void KConfigSkeletonTest::initTestCase()
 void KConfigSkeletonTest::init()
 {
     QFile::remove(QStandardPaths::writableLocation(QStandardPaths::GenericConfigLocation) + QLatin1String{"/kconfigskeletontestrc"});
-    s = new KConfigSkeleton(QStringLiteral("kconfigskeletontestrc"));
+    s = new KConfigSkeleton(KConfig::ConfigAssociation::KdeApp, QStringLiteral("kconfigskeletontestrc"));
     s->setCurrentGroup(QStringLiteral("MyGroup"));
     itemBool = s->addItemBool(QStringLiteral("MySetting1"), mMyBool, s_default_setting1);
     s->addItemColor(QStringLiteral("MySetting2"), mMyColor, s_default_setting2);

--- a/autotests/kconfigtest.cpp
+++ b/autotests/kconfigtest.cpp
@@ -1902,7 +1902,8 @@ void KConfigTest::testMoveValuesTo()
     QTemporaryFile targetFile;
     QVERIFY(targetFile.open());
     targetFile.close();
-    KConfigGroup targetGroup = KSharedConfig::openConfig(KConfig::ConfigAssociation::KdeApp, targetFile.fileName(), KConfig::SimpleConfig)->group("MoveToGroup");
+    KConfigGroup targetGroup =
+        KSharedConfig::openConfig(KConfig::ConfigAssociation::KdeApp, targetFile.fileName(), KConfig::SimpleConfig)->group("MoveToGroup");
 
     grp.moveValuesTo({"test1", "test_empty", "does_not_exist", "my_path", "GlobalKey"}, targetGroup);
     QVERIFY(grp.config()->isDirty());

--- a/autotests/kconfigtest.cpp
+++ b/autotests/kconfigtest.cpp
@@ -112,11 +112,11 @@ void KConfigTest::initTestCase()
     // to make sure all files from a previous failed run are deleted
     cleanupTestCase();
 
-    KSharedConfigPtr mainConfig = KSharedConfig::openConfig();
+    KSharedConfigPtr mainConfig = KSharedConfig::openConfig(KConfig::ConfigAssociation::KdeApp);
     mainConfig->group("Main").writeEntry("Key", "Value");
     mainConfig->sync();
 
-    KConfig sc(s_kconfig_test_subdir);
+    KConfig sc(KConfig::ConfigAssociation::KdeApp, s_kconfig_test_subdir);
 
     KConfigGroup cg(&sc, "AAA"); // deleted later by testDelete
     cg.writeEntry("stringEntry1", s_string_entry1, KConfig::Persistent | KConfig::Global);
@@ -219,7 +219,7 @@ void KConfigTest::initTestCase()
     QVERIFY2(QFile::exists(m_testConfigDir + QLatin1String("/kconfigtest")), qPrintable(m_testConfigDir + QLatin1String("/kconfigtest must exist")));
     QVERIFY2(QFile::exists(m_kdeGlobalsPath), qPrintable(m_kdeGlobalsPath + QStringLiteral(" must exist")));
 
-    KConfig sc1(s_test_subdir + QLatin1String("kdebugrc"), KConfig::SimpleConfig);
+    KConfig sc1(KConfig::ConfigAssociation::KdeApp, s_test_subdir + QLatin1String("kdebugrc"), KConfig::SimpleConfig);
     KConfigGroup sg0(&sc1, "0");
     sg0.writeEntry("AbortFatal", false);
     sg0.writeEntry("WarnOutput", 0);
@@ -227,14 +227,14 @@ void KConfigTest::initTestCase()
     QVERIFY(sc1.sync());
 
     // Setup stuff to test KConfig::addConfigSources()
-    KConfig devcfg(s_test_subdir + QLatin1String("specificrc"));
+    KConfig devcfg(KConfig::ConfigAssociation::KdeApp, s_test_subdir + QLatin1String("specificrc"));
     KConfigGroup devonlygrp(&devcfg, "Specific Only Group");
     devonlygrp.writeEntry("ExistingEntry", "DevValue");
     KConfigGroup devandbasegrp(&devcfg, "Shared Group");
     devandbasegrp.writeEntry("SomeSharedEntry", "DevValue");
     devandbasegrp.writeEntry("SomeSpecificOnlyEntry", "DevValue");
     QVERIFY(devcfg.sync());
-    KConfig basecfg(s_test_subdir + QLatin1String("baserc"));
+    KConfig basecfg(KConfig::ConfigAssociation::KdeApp, s_test_subdir + QLatin1String("baserc"));
     KConfigGroup basegrp(&basecfg, "Base Only Group");
     basegrp.writeEntry("ExistingEntry", "BaseValue");
     KConfigGroup baseanddevgrp(&basecfg, "Shared Group");
@@ -242,7 +242,7 @@ void KConfigTest::initTestCase()
     baseanddevgrp.writeEntry("SomeBaseOnlyEntry", "BaseValue");
     QVERIFY(basecfg.sync());
 
-    KConfig gecfg(s_test_subdir + QLatin1String("groupescapetest"), KConfig::SimpleConfig);
+    KConfig gecfg(KConfig::ConfigAssociation::KdeApp, s_test_subdir + QLatin1String("groupescapetest"), KConfig::SimpleConfig);
     cg = KConfigGroup(&gecfg, s_dollargroup);
     cg.writeEntry("entry", "doesntmatter");
 }
@@ -291,7 +291,7 @@ static QList<QByteArray> readLines(const QString &fileName = s_defaultArg)
 // see also testDefaults, which tests reverting with a defaults (global) file available
 void KConfigTest::testDirtyAfterRevert()
 {
-    KConfig sc(s_test_subdir + QLatin1String("kconfigtest_revert"));
+    KConfig sc(KConfig::ConfigAssociation::KdeApp, s_test_subdir + QLatin1String("kconfigtest_revert"));
 
     KConfigGroup cg(&sc, "Hello");
     cg.revertToDefault("does_not_exist");
@@ -315,19 +315,19 @@ void KConfigTest::testRevertAllEntries()
     // this tests the case were we revert (delete) all entries in a file,
     // leaving a blank file
     {
-        KConfig sc(s_test_subdir + QLatin1String("konfigtest2"), KConfig::SimpleConfig);
+        KConfig sc(KConfig::ConfigAssociation::KdeApp, s_test_subdir + QLatin1String("konfigtest2"), KConfig::SimpleConfig);
         KConfigGroup cg(&sc, "Hello");
         cg.writeEntry("Test", "Correct");
     }
 
     {
-        KConfig sc(s_test_subdir + QLatin1String("konfigtest2"), KConfig::SimpleConfig);
+        KConfig sc(KConfig::ConfigAssociation::KdeApp, s_test_subdir + QLatin1String("konfigtest2"), KConfig::SimpleConfig);
         KConfigGroup cg(&sc, "Hello");
         QCOMPARE(cg.readEntry("Test", "Default"), QStringLiteral("Correct"));
         cg.revertToDefault("Test");
     }
 
-    KConfig sc(s_test_subdir + QLatin1String("konfigtest2"), KConfig::SimpleConfig);
+    KConfig sc(KConfig::ConfigAssociation::KdeApp, s_test_subdir + QLatin1String("konfigtest2"), KConfig::SimpleConfig);
     KConfigGroup cg(&sc, "Hello");
     QCOMPARE(cg.readEntry("Test", "Default"), QStringLiteral("Default"));
 }
@@ -338,7 +338,7 @@ void KConfigTest::testSimple()
     const QStringList kdeglobals = QStandardPaths::locateAll(QStandardPaths::GenericConfigLocation, QStringLiteral("kdeglobals"));
     QVERIFY(!kdeglobals.isEmpty());
 
-    KConfig sc2(s_kconfig_test_subdir);
+    KConfig sc2(KConfig::ConfigAssociation::KdeApp, s_kconfig_test_subdir);
     QCOMPARE(sc2.name(), s_test_subdir + QLatin1String{"kconfigtest"});
 
     // make sure groupList() isn't returning something it shouldn't
@@ -385,9 +385,9 @@ void KConfigTest::testSimple()
 
 void KConfigTest::testDefaults()
 {
-    KConfig config(s_test_subdir + QLatin1String("defaulttest"), KConfig::NoGlobals);
+    KConfig config(KConfig::ConfigAssociation::KdeApp, s_test_subdir + QLatin1String("defaulttest"), KConfig::NoGlobals);
     const QString defaultsFile = s_test_subdir + QLatin1String("defaulttest.defaults");
-    KConfig defaults(defaultsFile, KConfig::SimpleConfig);
+    KConfig defaults(KConfig::ConfigAssociation::KdeApp, defaultsFile, KConfig::SimpleConfig);
     const QString defaultsFilePath = QStandardPaths::writableLocation(QStandardPaths::GenericConfigLocation) + QLatin1Char('/') + defaultsFile;
 
     const QString Default(QStringLiteral("Default"));
@@ -425,7 +425,7 @@ void KConfigTest::testDefaults()
     group.sync();
 
     // Check that everything is OK on disk, too
-    KConfig reader(s_test_subdir + QLatin1String("defaulttest"), KConfig::NoGlobals);
+    KConfig reader(KConfig::ConfigAssociation::KdeApp, s_test_subdir + QLatin1String("defaulttest"), KConfig::NoGlobals);
     reader.addConfigSources(QStringList{defaultsFilePath});
     KConfigGroup readerGroup = reader.group("any group");
     QCOMPARE(readerGroup.readEntry("entry1", QString()), Default);
@@ -434,7 +434,7 @@ void KConfigTest::testDefaults()
 
 void KConfigTest::testLocale()
 {
-    KConfig config(s_test_subdir + QLatin1String("kconfigtest.locales"), KConfig::SimpleConfig);
+    KConfig config(KConfig::ConfigAssociation::KdeApp, s_test_subdir + QLatin1String("kconfigtest.locales"), KConfig::SimpleConfig);
     const QString Translated(s_translated_string_entry1);
     const QString Untranslated(s_string_entry1);
 
@@ -459,7 +459,7 @@ void KConfigTest::testEncoding()
     const QString groupstr = QString::fromUtf8("UTF-8:\xc3\xb6l");
 
     const QString path = s_test_subdir + QLatin1String("kconfigtestencodings");
-    KConfig c(path);
+    KConfig c(KConfig::ConfigAssociation::KdeApp, path);
     KConfigGroup cg(&c, groupstr);
     cg.writeEntry("key", "value");
     QVERIFY(c.sync());
@@ -468,7 +468,7 @@ void KConfigTest::testEncoding()
     QCOMPARE(lines.count(), 2);
     QCOMPARE(lines.first(), QByteArray("[UTF-8:\xc3\xb6l]\n"));
 
-    KConfig c2(path);
+    KConfig c2(KConfig::ConfigAssociation::KdeApp, path);
     KConfigGroup cg2(&c2, groupstr);
     QCOMPARE(cg2.readEntry("key"), QStringLiteral("value"));
 
@@ -477,7 +477,7 @@ void KConfigTest::testEncoding()
 
 void KConfigTest::testLists()
 {
-    KConfig sc2(s_kconfig_test_subdir);
+    KConfig sc2(KConfig::ConfigAssociation::KdeApp, s_kconfig_test_subdir);
     KConfigGroup sc3(&sc2, "List Types");
 
     QCOMPARE(sc3.readEntry("stringListEntry", QStringList{}), s_stringlist_entry);
@@ -505,7 +505,7 @@ void KConfigTest::testLists()
 
 void KConfigTest::testPath()
 {
-    KConfig sc2(s_kconfig_test_subdir);
+    KConfig sc2(KConfig::ConfigAssociation::KdeApp, s_kconfig_test_subdir);
     KConfigGroup sc3(&sc2, "Path Type");
     QCOMPARE(sc3.readPathEntry(QStringLiteral("homepath"), QString{}), s_homepath);
     QCOMPARE(sc3.readPathEntry(QStringLiteral("homepathescape"), QString{}), s_homepath_escape);
@@ -529,7 +529,7 @@ void KConfigTest::testPath()
             << "noeol=foo" // no EOL
             ;
     }
-    KConfig cf2(s_test_subdir + QLatin1String("pathtest"));
+    KConfig cf2(KConfig::ConfigAssociation::KdeApp, s_test_subdir + QLatin1String("pathtest"));
     KConfigGroup group = cf2.group("Test Group");
     QVERIFY(group.hasKey("homePath"));
     QCOMPARE(group.readPathEntry("homePath", QString{}), s_homepath);
@@ -561,7 +561,7 @@ void KConfigTest::testPersistenceOfExpandFlagForPath()
     // 1st step: Open the config, add a new dummy entry and then sync the config
     // back to the storage.
     {
-        KConfig sc2(s_kconfig_test_subdir);
+        KConfig sc2(KConfig::ConfigAssociation::KdeApp, s_kconfig_test_subdir);
         KConfigGroup sc3(&sc2, "Path Type");
         sc3.writeEntry("dummy", "dummy");
         QVERIFY(sc2.sync());
@@ -583,7 +583,7 @@ void KConfigTest::testPathQtHome()
             << "cacheDir[$e]=$QT_CACHE_HOME/kconfigtest\n"
             << "configDir[$e]=$QT_CONFIG_HOME/kconfigtest\n";
     }
-    KConfig cf2(s_test_subdir + QLatin1String("pathtest"));
+    KConfig cf2(KConfig::ConfigAssociation::KdeApp, s_test_subdir + QLatin1String("pathtest"));
     KConfigGroup group = cf2.group("Test Group");
     qunsetenv("QT_DATA_HOME");
     qunsetenv("QT_CACHE_HOME");
@@ -610,7 +610,7 @@ void KConfigTest::testPathQtHome()
 
 void KConfigTest::testComplex()
 {
-    KConfig sc2(s_kconfig_test_subdir);
+    KConfig sc2(KConfig::ConfigAssociation::KdeApp, s_kconfig_test_subdir);
     KConfigGroup sc3(&sc2, "Complex Types");
 
     QCOMPARE(sc3.readEntry("pointEntry", QPoint()), s_point_entry);
@@ -630,7 +630,7 @@ void KConfigTest::testEnums()
 #if defined(_MSC_VER) && _MSC_VER == 1600
     QSKIP("Visual C++ 2010 can't compile this test");
 #endif
-    KConfig sc(s_kconfig_test_subdir);
+    KConfig sc(KConfig::ConfigAssociation::KdeApp, s_kconfig_test_subdir);
     KConfigGroup sc3(&sc, "Enum Types");
 
     QCOMPARE(sc3.readEntry("enum-10"), QStringLiteral("Tens"));
@@ -651,7 +651,7 @@ void KConfigTest::testEnums()
 
 void KConfigTest::testEntryMap()
 {
-    KConfig sc(s_kconfig_test_subdir);
+    KConfig sc(KConfig::ConfigAssociation::KdeApp, s_kconfig_test_subdir);
     KConfigGroup cg(&sc, "Hello");
     QMap<QString, QString> entryMap = cg.entryMap();
     qDebug() << entryMap.keys();
@@ -675,7 +675,7 @@ void KConfigTest::testEntryMap()
 
 void KConfigTest::testInvalid()
 {
-    KConfig sc(s_kconfig_test_subdir);
+    KConfig sc(KConfig::ConfigAssociation::KdeApp, s_kconfig_test_subdir);
 
     // all of these should print a message to the kdebug.dbg file
     KConfigGroup sc3(&sc, "Invalid Types");
@@ -742,7 +742,7 @@ void KConfigTest::testInvalid()
 
 void KConfigTest::testChangeGroup()
 {
-    KConfig sc(s_kconfig_test_subdir);
+    KConfig sc(KConfig::ConfigAssociation::KdeApp, s_kconfig_test_subdir);
     KConfigGroup sc3(&sc, "Hello");
     QCOMPARE(sc3.name(), QStringLiteral("Hello"));
     KConfigGroup newGroup(sc3);
@@ -760,14 +760,14 @@ void KConfigTest::testDeleteEntry()
     const QString configFile = s_test_subdir + QLatin1String("kconfigdeletetest");
 
     {
-        KConfig conf(configFile);
+        KConfig conf(KConfig::ConfigAssociation::KdeApp, configFile);
         conf.group("Hello").writeEntry("DelKey", "ToBeDeleted");
     }
     const QList<QByteArray> lines = readLines(configFile);
     Q_ASSERT(lines.contains("[Hello]\n"));
     Q_ASSERT(lines.contains("DelKey=ToBeDeleted\n"));
 
-    KConfig sc(configFile);
+    KConfig sc(KConfig::ConfigAssociation::KdeApp, configFile);
     KConfigGroup group(&sc, "Hello");
 
     group.deleteEntry("DelKey");
@@ -780,7 +780,7 @@ void KConfigTest::testDeleteEntry()
 
 void KConfigTest::testDelete()
 {
-    KConfig sc(s_kconfig_test_subdir);
+    KConfig sc(KConfig::ConfigAssociation::KdeApp, s_kconfig_test_subdir);
 
     KConfigGroup ct(&sc, "Complex Types");
 
@@ -834,7 +834,7 @@ void KConfigTest::testDelete()
     QVERIFY(lines.contains("[Hello]\n")); // a group that was not deleted
 
     // test for entries that are marked as deleted when there is no default
-    KConfig cf(s_kconfig_test_subdir, KConfig::SimpleConfig); // make sure there are no defaults
+    KConfig cf(KConfig::ConfigAssociation::KdeApp, s_kconfig_test_subdir, KConfig::SimpleConfig); // make sure there are no defaults
     cg = cf.group("Portable Devices");
     cg.writeEntry("devices|manual|(null)", "whatever");
     cg.writeEntry("devices|manual|/mnt/ipod", "/mnt/ipod");
@@ -858,7 +858,7 @@ void KConfigTest::testDelete()
 
 void KConfigTest::testDefaultGroup()
 {
-    KConfig sc(s_kconfig_test_subdir);
+    KConfig sc(KConfig::ConfigAssociation::KdeApp, s_kconfig_test_subdir);
     KConfigGroup defaultGroup(&sc, "<default>");
     QCOMPARE(defaultGroup.name(), QStringLiteral("<default>"));
     QVERIFY(!defaultGroup.exists());
@@ -869,7 +869,7 @@ void KConfigTest::testDefaultGroup()
 
     {
         // Test reading it
-        KConfig sc2(s_kconfig_test_subdir);
+        KConfig sc2(KConfig::ConfigAssociation::KdeApp, s_kconfig_test_subdir);
         KConfigGroup defaultGroup2(&sc2, "<default>");
         QCOMPARE(defaultGroup2.name(), QStringLiteral("<default>"));
         QVERIFY(defaultGroup2.exists());
@@ -877,7 +877,7 @@ void KConfigTest::testDefaultGroup()
     }
     {
         // Test reading it
-        KConfig sc2(s_kconfig_test_subdir);
+        KConfig sc2(KConfig::ConfigAssociation::KdeApp, s_kconfig_test_subdir);
         KConfigGroup emptyGroup(&sc2, "");
         QCOMPARE(emptyGroup.name(), QStringLiteral("<default>"));
         QVERIFY(emptyGroup.exists());
@@ -905,7 +905,7 @@ void KConfigTest::testDefaultGroup()
 
 void KConfigTest::testEmptyGroup()
 {
-    KConfig sc(s_kconfig_test_subdir);
+    KConfig sc(KConfig::ConfigAssociation::KdeApp, s_kconfig_test_subdir);
     KConfigGroup emptyGroup(&sc, "");
     QCOMPARE(emptyGroup.name(), QStringLiteral("<default>")); // confusing, heh?
     QVERIFY(!emptyGroup.exists());
@@ -916,7 +916,7 @@ void KConfigTest::testEmptyGroup()
 
     {
         // Test reading it
-        KConfig sc2(s_kconfig_test_subdir);
+        KConfig sc2(KConfig::ConfigAssociation::KdeApp, s_kconfig_test_subdir);
         KConfigGroup defaultGroup(&sc2, "<default>");
         QCOMPARE(defaultGroup.name(), QStringLiteral("<default>"));
         QVERIFY(defaultGroup.exists());
@@ -924,7 +924,7 @@ void KConfigTest::testEmptyGroup()
     }
     {
         // Test reading it
-        KConfig sc2(s_kconfig_test_subdir);
+        KConfig sc2(KConfig::ConfigAssociation::KdeApp, s_kconfig_test_subdir);
         KConfigGroup emptyGroup2(&sc2, "");
         QCOMPARE(emptyGroup2.name(), QStringLiteral("<default>"));
         QVERIFY(emptyGroup2.exists());
@@ -989,7 +989,7 @@ void KConfigTest::testCascadingWithLocale()
         << "Other=English Only\n";
     local.close();
 
-    KConfig config(s_test_subdir + QLatin1String("foo.desktop"));
+    KConfig config(KConfig::ConfigAssociation::KdeApp, s_test_subdir + QLatin1String("foo.desktop"));
     KConfigGroup group = config.group("Group");
     QCOMPARE(group.readEntry("FromGlobal"), QStringLiteral("true"));
     QCOMPARE(group.readEntry("FromLocal"), QStringLiteral("true"));
@@ -1007,7 +1007,7 @@ void KConfigTest::testMerge()
 {
     DefaultLocale defaultLocale;
     QLocale::setDefault(QLocale::c());
-    KConfig config(s_test_subdir + QLatin1String("mergetest"), KConfig::SimpleConfig);
+    KConfig config(KConfig::ConfigAssociation::KdeApp, s_test_subdir + QLatin1String("mergetest"), KConfig::SimpleConfig);
 
     KConfigGroup cg = config.group("some group");
     cg.writeEntry("entry", " random entry");
@@ -1061,7 +1061,7 @@ void KConfigTest::testImmutable()
             << "[group][subgroup][$i]\n";
     }
 
-    KConfig config(s_test_subdir + QLatin1String("immutabletest"), KConfig::SimpleConfig);
+    KConfig config(KConfig::ConfigAssociation::KdeApp, s_test_subdir + QLatin1String("immutabletest"), KConfig::SimpleConfig);
     QVERIFY(config.isGroupImmutable(QByteArray()));
     KConfigGroup cg = config.group(QByteArray());
     QVERIFY(cg.isEntryImmutable("entry1"));
@@ -1083,7 +1083,7 @@ void KConfigTest::testOptionOrder()
             << "entry2=unlocalized\n"
             << "entry2[$i][de_DE]=t2\n";
     }
-    KConfig config(s_test_subdir + QLatin1String("doubleattrtest"), KConfig::SimpleConfig);
+    KConfig config(KConfig::ConfigAssociation::KdeApp, s_test_subdir + QLatin1String("doubleattrtest"), KConfig::SimpleConfig);
     config.setLocale(QStringLiteral("de_DE"));
     KConfigGroup cg3 = config.group("group3");
     QVERIFY(!cg3.isImmutable());
@@ -1112,13 +1112,13 @@ void KConfigTest::testOptionOrder()
 
 void KConfigTest::testGroupEscape()
 {
-    KConfig config(s_test_subdir + QLatin1String("groupescapetest"), KConfig::SimpleConfig);
+    KConfig config(KConfig::ConfigAssociation::KdeApp, s_test_subdir + QLatin1String("groupescapetest"), KConfig::SimpleConfig);
     QVERIFY(config.group(s_dollargroup).exists());
 }
 
 void KConfigTest::testSubGroup()
 {
-    KConfig sc(s_kconfig_test_subdir);
+    KConfig sc(KConfig::ConfigAssociation::KdeApp, s_kconfig_test_subdir);
     KConfigGroup cg(&sc, "ParentGroup");
     QCOMPARE(cg.readEntry("parentgrpstring", ""), QStringLiteral("somevalue"));
     KConfigGroup subcg1(&cg, "SubGroup1");
@@ -1204,7 +1204,7 @@ void KConfigTest::testSubGroup()
 
 void KConfigTest::testAddConfigSources()
 {
-    KConfig cf(s_test_subdir + QLatin1String("specificrc"));
+    KConfig cf(KConfig::ConfigAssociation::KdeApp, s_test_subdir + QLatin1String("specificrc"));
 
     cf.addConfigSources(QStringList{m_testConfigDir + QLatin1String("/baserc")});
     cf.reparseConfiguration();
@@ -1226,7 +1226,7 @@ void KConfigTest::testAddConfigSources()
 
     QVERIFY(cf.sync());
 
-    KConfig plaincfg(s_test_subdir + QLatin1String("specificrc"));
+    KConfig plaincfg(KConfig::ConfigAssociation::KdeApp, s_test_subdir + QLatin1String("specificrc"));
 
     KConfigGroup newgrp2(&plaincfg, "New Group");
     QCOMPARE(newgrp2.readEntry("New Entry", ""), QStringLiteral("SomeValue"));
@@ -1237,14 +1237,14 @@ void KConfigTest::testAddConfigSources()
 
 void KConfigTest::testGroupCopyTo()
 {
-    KConfig cf1(s_kconfig_test_subdir);
+    KConfig cf1(KConfig::ConfigAssociation::KdeApp, s_kconfig_test_subdir);
     KConfigGroup original = cf1.group("Enum Types");
 
     KConfigGroup copy = cf1.group("Enum Types Copy");
     original.copyTo(&copy); // copy from one group to another
     QCOMPARE(copy.entryMap(), original.entryMap());
 
-    KConfig cf2(s_test_subdir + QLatin1String("copy_of_kconfigtest"), KConfig::SimpleConfig);
+    KConfig cf2(KConfig::ConfigAssociation::KdeApp, s_test_subdir + QLatin1String("copy_of_kconfigtest"), KConfig::SimpleConfig);
     QVERIFY(!cf2.hasGroup(original.name()));
     QVERIFY(!cf2.hasGroup(copy.name()));
 
@@ -1257,7 +1257,7 @@ void KConfigTest::testGroupCopyTo()
 
 void KConfigTest::testConfigCopyToSync()
 {
-    KConfig cf1(s_kconfig_test_subdir);
+    KConfig cf1(KConfig::ConfigAssociation::KdeApp, s_kconfig_test_subdir);
     // Prepare source file
     KConfigGroup group(&cf1, "CopyToTest");
     group.writeEntry("Type", "Test");
@@ -1267,7 +1267,7 @@ void KConfigTest::testConfigCopyToSync()
     const QString destination = m_testConfigDir + QLatin1String("/kconfigcopytotest");
     QFile::remove(destination);
 
-    KConfig cf2(s_test_subdir + QLatin1String("kconfigcopytotest"));
+    KConfig cf2(KConfig::ConfigAssociation::KdeApp, s_test_subdir + QLatin1String("kconfigcopytotest"));
     KConfigGroup group2(&cf2, "CopyToTest");
 
     group.copyTo(&group2);
@@ -1281,7 +1281,7 @@ void KConfigTest::testConfigCopyToSync()
 
 void KConfigTest::testConfigCopyTo()
 {
-    KConfig cf1(s_kconfig_test_subdir);
+    KConfig cf1(KConfig::ConfigAssociation::KdeApp, s_kconfig_test_subdir);
     {
         // Prepare source file
         KConfigGroup group(&cf1, "CopyToTest");
@@ -1293,7 +1293,7 @@ void KConfigTest::testConfigCopyTo()
         // Copy to "destination"
         const QString destination = m_testConfigDir + QLatin1String("/kconfigcopytotest");
         QFile::remove(destination);
-        KConfig cf2;
+        KConfig cf2(KConfig::ConfigAssociation::KdeApp);
         cf1.copyTo(destination, &cf2);
         KConfigGroup group2(&cf2, "CopyToTest");
         QString testVal = group2.readEntry("Type");
@@ -1303,7 +1303,7 @@ void KConfigTest::testConfigCopyTo()
     }
 
     // Check copied config file on disk
-    KConfig cf3(s_test_subdir + QLatin1String("kconfigcopytotest"));
+    KConfig cf3(KConfig::ConfigAssociation::KdeApp, s_test_subdir + QLatin1String("kconfigcopytotest"));
     KConfigGroup group3(&cf3, "CopyToTest");
     QString testVal = group3.readEntry("Type");
     QCOMPARE(testVal, QStringLiteral("Test"));
@@ -1311,7 +1311,7 @@ void KConfigTest::testConfigCopyTo()
 
 void KConfigTest::testReparent()
 {
-    KConfig cf(s_kconfig_test_subdir);
+    KConfig cf(KConfig::ConfigAssociation::KdeApp, s_kconfig_test_subdir);
     const QString name(QStringLiteral("Enum Types"));
     KConfigGroup group = cf.group(name);
     const QMap<QString, QString> originalMap = group.entryMap();
@@ -1347,7 +1347,7 @@ void KConfigTest::testWriteOnSync()
 {
     QDateTime oldStamp;
     QDateTime newStamp;
-    KConfig sc(s_kconfig_test_subdir, KConfig::IncludeGlobals);
+    KConfig sc(KConfig::ConfigAssociation::KdeApp, s_kconfig_test_subdir, KConfig::IncludeGlobals);
 
     // Age the timestamp of global config file a few sec, and collect it.
     QString globFile = m_kdeGlobalsPath;
@@ -1382,7 +1382,7 @@ void KConfigTest::testWriteOnSync()
 
 void KConfigTest::testFailOnReadOnlyFileSync()
 {
-    KConfig sc(s_test_subdir + QLatin1String("kconfigfailonreadonlytest"));
+    KConfig sc(KConfig::ConfigAssociation::KdeApp, s_test_subdir + QLatin1String("kconfigfailonreadonlytest"));
     KConfigGroup cgLocal(&sc, "Locals");
 
     cgLocal.writeEntry("someLocalString", "whatever");
@@ -1408,7 +1408,7 @@ void KConfigTest::testDirtyOnEqual()
 {
     QDateTime oldStamp;
     QDateTime newStamp;
-    KConfig sc(s_kconfig_test_subdir);
+    KConfig sc(KConfig::ConfigAssociation::KdeApp, s_kconfig_test_subdir);
 
     // Initialize value
     KConfigGroup cgLocal(&sc, "random");
@@ -1442,7 +1442,7 @@ void KConfigTest::testDirtyOnEqualOverdo()
         4);
     QByteArray defvalr;
 
-    KConfig sc(s_kconfig_test_subdir);
+    KConfig sc(KConfig::ConfigAssociation::KdeApp, s_kconfig_test_subdir);
     KConfigGroup cgLocal(&sc, "random");
     cgLocal.writeEntry("someKey", val1);
     QCOMPARE(cgLocal.readEntry("someKey", defvalr), val1);
@@ -1474,7 +1474,7 @@ void KConfigTest::testSyncOnExit()
     // Often, the KGlobalPrivate global static's destructor ends up calling ~KConfig ->
     // KConfig::sync ... and if that code triggers KGlobal code again then things could crash.
     // So here's a test for modifying KSharedConfig::openConfig() and not syncing, the process exit will sync.
-    KConfigGroup grp(KSharedConfig::openConfig(s_test_subdir + QLatin1String("syncOnExitRc")), "syncOnExit");
+    KConfigGroup grp(KSharedConfig::openConfig(KConfig::ConfigAssociation::KdeApp, s_test_subdir + QLatin1String("syncOnExitRc")), "syncOnExit");
     grp.writeEntry("key", "value");
 }
 
@@ -1483,13 +1483,13 @@ void KConfigTest::testSharedConfig()
     // Can I use a KConfigGroup even after the KSharedConfigPtr goes out of scope?
     KConfigGroup myConfigGroup;
     {
-        KSharedConfigPtr config = KSharedConfig::openConfig(s_kconfig_test_subdir);
+        KSharedConfigPtr config = KSharedConfig::openConfig(KConfig::ConfigAssociation::KdeApp, s_kconfig_test_subdir);
         myConfigGroup = KConfigGroup(config, "Hello");
     }
     QCOMPARE(myConfigGroup.readEntry("stringEntry1"), s_string_entry1);
 
     // Get the main config
-    KSharedConfigPtr mainConfig = KSharedConfig::openConfig();
+    KSharedConfigPtr mainConfig = KSharedConfig::openConfig(KConfig::ConfigAssociation::KdeApp);
     KConfigGroup mainGroup(mainConfig, "Main");
     QCOMPARE(mainGroup.readEntry("Key", QString{}), QStringLiteral("Value"));
 }
@@ -1518,7 +1518,7 @@ void KConfigTest::testLocaleConfig()
 
     // Load the testdata
     QVERIFY(QFile::exists(file));
-    KConfig config(file);
+    KConfig config(KConfig::ConfigAssociation::KdeApp, file);
     config.setLocale(QStringLiteral("ca"));
 
     // This group has only localized values. That is not supported. The values
@@ -1568,7 +1568,7 @@ void KConfigTest::testDeleteWhenLocalized()
 
     // Load the testdata. We start in locale "ca".
     QVERIFY(QFile::exists(file));
-    KConfig config(file);
+    KConfig config(KConfig::ConfigAssociation::KdeApp, file);
     config.setLocale(QStringLiteral("ca"));
     KConfigGroup cg(&config, "Test4711");
 
@@ -1674,13 +1674,13 @@ void KConfigTest::testDeleteWhenLocalized()
 void KConfigTest::testKdeGlobals()
 {
     {
-        KConfig glob(QStringLiteral("kdeglobals"));
+        KConfig glob(KConfig::ConfigAssociation::KdeApp, QStringLiteral("kdeglobals"));
         KConfigGroup general(&glob, "General");
         general.writeEntry("testKG", "1");
         QVERIFY(glob.sync());
     }
 
-    KConfig globRead(QStringLiteral("kdeglobals"));
+    KConfig globRead(KConfig::ConfigAssociation::KdeApp, QStringLiteral("kdeglobals"));
     const KConfigGroup general(&globRead, "General");
     QCOMPARE(general.readEntry("testKG"), QStringLiteral("1"));
 
@@ -1691,7 +1691,7 @@ void KConfigTest::testKdeGlobals()
 
     // Writing using NoGlobals
     {
-        KConfig glob(QStringLiteral("kdeglobals"), KConfig::NoGlobals);
+        KConfig glob(KConfig::ConfigAssociation::KdeApp, QStringLiteral("kdeglobals"), KConfig::NoGlobals);
         KConfigGroup general(&glob, "General");
         general.writeEntry("testKG", "2");
         QVERIFY(glob.sync());
@@ -1701,7 +1701,7 @@ void KConfigTest::testKdeGlobals()
 
     // Reading using NoGlobals
     {
-        KConfig globReadNoGlob(QStringLiteral("kdeglobals"), KConfig::NoGlobals);
+        KConfig globReadNoGlob(KConfig::ConfigAssociation::KdeApp, QStringLiteral("kdeglobals"), KConfig::NoGlobals);
         const KConfigGroup generalNoGlob(&globReadNoGlob, "General");
         QCOMPARE(generalNoGlob.readEntry("testKG"), QStringLiteral("2"));
     }
@@ -1711,7 +1711,7 @@ void KConfigTest::testLocalDeletion()
 {
     // Prepare kdeglobals
     {
-        KConfig glob(QStringLiteral("kdeglobals"));
+        KConfig glob(KConfig::ConfigAssociation::KdeApp, QStringLiteral("kdeglobals"));
         KConfigGroup general(&glob, "OwnTestGroup");
         general.writeEntry("GlobalKey", "DontTouchMe");
         QVERIFY(glob.sync());
@@ -1722,7 +1722,7 @@ void KConfigTest::testLocalDeletion()
 
     // Write into kconfigtest, including deleting GlobalKey
     {
-        KConfig mainConfig(s_kconfig_test_subdir);
+        KConfig mainConfig(KConfig::ConfigAssociation::KdeApp, s_kconfig_test_subdir);
         KConfigGroup mainGroup(&mainConfig, "OwnTestGroup");
         mainGroup.writeEntry("LocalKey", QStringLiteral("LocalValue"));
         mainGroup.writeEntry("GlobalWrite", QStringLiteral("GlobalValue"), KConfig::Persistent | KConfig::Global); // goes to kdeglobals
@@ -1739,7 +1739,7 @@ void KConfigTest::testLocalDeletion()
 
     // Check what ended up in kdeglobals
     {
-        KConfig globReadNoGlob(QStringLiteral("kdeglobals"), KConfig::NoGlobals);
+        KConfig globReadNoGlob(KConfig::ConfigAssociation::KdeApp, QStringLiteral("kdeglobals"), KConfig::NoGlobals);
         const KConfigGroup generalNoGlob(&globReadNoGlob, "OwnTestGroup");
         QCOMPARE(generalNoGlob.readEntry("GlobalKey"), QStringLiteral("DontTouchMe"));
         QCOMPARE(generalNoGlob.readEntry("GlobalWrite"), QStringLiteral("GlobalValue"));
@@ -1751,7 +1751,7 @@ void KConfigTest::testLocalDeletion()
 
     // Check what we see when re-reading the config file
     {
-        KConfig mainConfig(s_kconfig_test_subdir);
+        KConfig mainConfig(KConfig::ConfigAssociation::KdeApp, s_kconfig_test_subdir);
         KConfigGroup mainGroup(&mainConfig, "OwnTestGroup");
         QCOMPARE(mainGroup.readEntry("GlobalKey", "Default"), QStringLiteral("Default")); // key is gone
         QCOMPARE(mainGroup.keyList(), expectedKeys);
@@ -1760,7 +1760,7 @@ void KConfigTest::testLocalDeletion()
 
 void KConfigTest::testAnonymousConfig()
 {
-    KConfig anonConfig(QString(), KConfig::SimpleConfig);
+    KConfig anonConfig(KConfig::ConfigAssociation::KdeApp, QString(), KConfig::SimpleConfig);
     KConfigGroup general(&anonConfig, "General");
     QCOMPARE(general.readEntry("testKG"), QString()); // no kdeglobals merging
     general.writeEntry("Foo", "Bar");
@@ -1771,7 +1771,7 @@ void KConfigTest::testQByteArrayUtf8()
 {
     QTemporaryFile file;
     QVERIFY(file.open());
-    KConfig config(file.fileName(), KConfig::SimpleConfig);
+    KConfig config(KConfig::ConfigAssociation::KdeApp, file.fileName(), KConfig::SimpleConfig);
     KConfigGroup general(&config, "General");
     QByteArray bytes(256, '\0');
     for (int i = 0; i < 256; i++) {
@@ -1803,7 +1803,7 @@ void KConfigTest::testQByteArrayUtf8()
 #undef VALUE
 
     // check that reading works
-    KConfig config2(file.fileName(), KConfig::SimpleConfig);
+    KConfig config2(KConfig::ConfigAssociation::KdeApp, file.fileName(), KConfig::SimpleConfig);
     KConfigGroup general2(&config2, "General");
     QCOMPARE(bytes, general2.readEntry("Utf8", QByteArray()));
 }
@@ -1837,7 +1837,7 @@ void KConfigTest::testQStringUtf8()
     const QByteArray serialized = d[1];
     QTemporaryFile file;
     QVERIFY(file.open());
-    KConfig config(file.fileName(), KConfig::SimpleConfig);
+    KConfig config(KConfig::ConfigAssociation::KdeApp, file.fileName(), KConfig::SimpleConfig);
     KConfigGroup general(&config, "General");
     general.writeEntry("key", value);
     config.sync();
@@ -1852,7 +1852,7 @@ void KConfigTest::testQStringUtf8()
     QCOMPARE(fileBytes, QByteArrayLiteral("[General]\nkey=") + serialized + QByteArrayLiteral("\n"));
 
     // check that reading works
-    KConfig config2(file.fileName(), KConfig::SimpleConfig);
+    KConfig config2(KConfig::ConfigAssociation::KdeApp, file.fileName(), KConfig::SimpleConfig);
     KConfigGroup general2(&config2, "General");
     QCOMPARE(value, general2.readEntry("key", QByteArray()));
 }
@@ -1862,7 +1862,7 @@ void KConfigTest::testNewlines()
     // test that kconfig always uses the native line endings
     QTemporaryFile file;
     QVERIFY(file.open());
-    KConfig anonConfig(file.fileName(), KConfig::SimpleConfig);
+    KConfig anonConfig(KConfig::ConfigAssociation::KdeApp, file.fileName(), KConfig::SimpleConfig);
     KConfigGroup general(&anonConfig, "General");
     general.writeEntry("Foo", "Bar");
     general.writeEntry("Bar", "Foo");
@@ -1884,13 +1884,13 @@ void KConfigTest::testMoveValuesTo()
     QVERIFY(file.open());
     // Prepare kdeglobals
     {
-        KConfig glob(QStringLiteral("kdeglobals"));
+        KConfig glob(KConfig::ConfigAssociation::KdeApp, QStringLiteral("kdeglobals"));
         KConfigGroup general(&glob, "TestGroup");
         general.writeEntry("GlobalKey", "PlsDeleteMe");
         QVERIFY(glob.sync());
     }
 
-    KConfigGroup grp = KSharedConfig::openConfig(file.fileName())->group("TestGroup");
+    KConfigGroup grp = KSharedConfig::openConfig(KConfig::ConfigAssociation::KdeApp, file.fileName())->group("TestGroup");
 
     grp.writeEntry("test1", "first_value");
     grp.writeEntry("test_empty", "");
@@ -1902,7 +1902,7 @@ void KConfigTest::testMoveValuesTo()
     QTemporaryFile targetFile;
     QVERIFY(targetFile.open());
     targetFile.close();
-    KConfigGroup targetGroup = KSharedConfig::openConfig(targetFile.fileName(), KConfig::SimpleConfig)->group("MoveToGroup");
+    KConfigGroup targetGroup = KSharedConfig::openConfig(KConfig::ConfigAssociation::KdeApp, targetFile.fileName(), KConfig::SimpleConfig)->group("MoveToGroup");
 
     grp.moveValuesTo({"test1", "test_empty", "does_not_exist", "my_path", "GlobalKey"}, targetGroup);
     QVERIFY(grp.config()->isDirty());
@@ -1934,7 +1934,7 @@ void KConfigTest::testXdgListEntry()
         << "Key6=1;2\\;3;;\n";
     out.flush();
     file.close();
-    KConfig anonConfig(file.fileName(), KConfig::SimpleConfig);
+    KConfig anonConfig(KConfig::ConfigAssociation::KdeApp, file.fileName(), KConfig::SimpleConfig);
     KConfigGroup grp = anonConfig.group("General");
     QStringList invalidList; // use this as a default when an empty list is expected
     invalidList << QStringLiteral("Error! Default value read!");
@@ -1977,15 +1977,15 @@ void KConfigTest::testNotify()
     QSKIP("KConfig notification requires DBus");
 #endif
 
-    KConfig config(s_kconfig_test_subdir);
+    KConfig config(KConfig::ConfigAssociation::KdeApp, s_kconfig_test_subdir);
     auto myConfigGroup = KConfigGroup(&config, "TopLevelGroup");
 
     // mimics a config in another process, which is watching for events
-    auto remoteConfig = KSharedConfig::openConfig(s_kconfig_test_subdir);
+    auto remoteConfig = KSharedConfig::openConfig(KConfig::ConfigAssociation::KdeApp, s_kconfig_test_subdir);
     KConfigWatcher::Ptr watcher = KConfigWatcher::create(remoteConfig);
 
     // some random config that shouldn't be changing when kconfigtest changes, only on kdeglobals
-    auto otherRemoteConfig = KSharedConfig::openConfig(s_test_subdir + QLatin1String("kconfigtest2"));
+    auto otherRemoteConfig = KSharedConfig::openConfig(KConfig::ConfigAssociation::KdeApp, s_test_subdir + QLatin1String("kconfigtest2"));
     KConfigWatcher::Ptr otherWatcher = KConfigWatcher::create(otherRemoteConfig);
 
     QSignalSpy watcherSpy(watcher.data(), &KConfigWatcher::configChanged);
@@ -2055,7 +2055,7 @@ void KConfigTest::testNotify()
 
 void KConfigTest::testKAuthorizeEnums()
 {
-    KSharedConfig::Ptr config = KSharedConfig::openConfig();
+    KSharedConfig::Ptr config = KSharedConfig::openConfig(KConfig::ConfigAssociation::KdeApp);
     KConfigGroup actionRestrictions = config->group("KDE Action Restrictions");
     actionRestrictions.writeEntry("shell_access", false);
     actionRestrictions.writeEntry("action/open_with", false);
@@ -2071,12 +2071,12 @@ void KConfigTest::testKAuthorizeEnums()
 void KConfigTest::testKdeglobalsVsDefault()
 {
     // Add testRestore key with global value in kdeglobals
-    KConfig glob(QStringLiteral("kdeglobals"));
+    KConfig glob(KConfig::ConfigAssociation::KdeApp, QStringLiteral("kdeglobals"));
     KConfigGroup generalGlob(&glob, "General");
     generalGlob.writeEntry("testRestore", "global");
     QVERIFY(glob.sync());
 
-    KConfig local(s_test_subdir + QLatin1String("restorerc"));
+    KConfig local(KConfig::ConfigAssociation::KdeApp, s_test_subdir + QLatin1String("restorerc"));
     KConfigGroup generalLocal(&local, "General");
     // Check if we get global and not the default value from cpp (defaultcpp) when reading data from restorerc
     QCOMPARE(generalLocal.readEntry("testRestore", "defaultcpp"), QStringLiteral("global"));

--- a/autotests/kdesktopfiletest.cpp
+++ b/autotests/kdesktopfiletest.cpp
@@ -23,7 +23,7 @@ void KDesktopFileTest::initTestCase()
 {
     QStandardPaths::setTestModeEnabled(true);
 
-    KConfigGroup actionRestrictions(KSharedConfig::openConfig(), "KDE Action Restrictions");
+    KConfigGroup actionRestrictions(KSharedConfig::openConfig(KConfig::ConfigAssociation::KdeApp), "KDE Action Restrictions");
     actionRestrictions.writeEntry("someBlockedAction", false);
 }
 

--- a/autotests/ksharedconfig_in_global_object.cpp
+++ b/autotests/ksharedconfig_in_global_object.cpp
@@ -22,14 +22,14 @@ public:
 void Tester::initConfig()
 {
     fprintf(stderr, "app Tester\n");
-    KConfigGroup group(KSharedConfig::openConfig(), "test");
+    KConfigGroup group(KSharedConfig::openConfig(KConfig::ConfigAssociation::KdeApp), "test");
     group.writeEntry("test", 0);
 }
 
 Tester::~Tester()
 {
     fprintf(stderr, "app ~Tester\n");
-    KConfigGroup group(KSharedConfig::openConfig(), "test");
+    KConfigGroup group(KSharedConfig::openConfig(KConfig::ConfigAssociation::KdeApp), "test");
     group.writeEntry("test", 1);
 }
 
@@ -40,7 +40,7 @@ int main(int argc, char **argv)
     qputenv("QT_FATAL_WARNINGS", "1");
     QCoreApplication app(argc, argv);
 
-    KSharedConfig::Ptr config = KSharedConfig::openConfig();
+    KSharedConfig::Ptr config = KSharedConfig::openConfig(KConfig::ConfigAssociation::KdeApp);
 
     Tester *t = globalTestObject();
     t->initConfig();

--- a/autotests/ksharedconfigtest.cpp
+++ b/autotests/ksharedconfigtest.cpp
@@ -34,8 +34,8 @@ void KSharedConfigTest::initTestCase()
 
 void KSharedConfigTest::testUnicity()
 {
-    KSharedConfig::Ptr cfg1 = KSharedConfig::openConfig();
-    KSharedConfig::Ptr cfg2 = KSharedConfig::openConfig();
+    KSharedConfig::Ptr cfg1 = KSharedConfig::openConfig(KConfig::ConfigAssociation::KdeApp);
+    KSharedConfig::Ptr cfg2 = KSharedConfig::openConfig(KConfig::ConfigAssociation::KdeApp);
     QCOMPARE(cfg1.data(), cfg2.data());
 }
 
@@ -43,11 +43,11 @@ void KSharedConfigTest::testReadWrite()
 {
     const int value = 1;
     {
-        KConfigGroup cg(KSharedConfig::openConfig(), "KSharedConfigTest");
+        KConfigGroup cg(KSharedConfig::openConfig(KConfig::ConfigAssociation::KdeApp), "KSharedConfigTest");
         cg.writeEntry("NumKey", value);
     }
     {
-        KConfigGroup cg(KSharedConfig::openConfig(), "KSharedConfigTest");
+        KConfigGroup cg(KSharedConfig::openConfig(KConfig::ConfigAssociation::KdeApp), "KSharedConfigTest");
         QCOMPARE(cg.readEntry("NumKey", 0), 1);
     }
 }
@@ -56,14 +56,14 @@ void KSharedConfigTest::testReadWriteSync()
 {
     const int value = 1;
     {
-        KConfigGroup cg(KSharedConfig::openConfig(), "KSharedConfigTest");
+        KConfigGroup cg(KSharedConfig::openConfig(KConfig::ConfigAssociation::KdeApp), "KSharedConfigTest");
         cg.writeEntry("NumKey", value);
     }
     QVERIFY(!QFile::exists(m_path));
-    QVERIFY(KSharedConfig::openConfig()->sync());
+    QVERIFY(KSharedConfig::openConfig(KConfig::ConfigAssociation::KdeApp)->sync());
     QVERIFY(QFile::exists(m_path));
     {
-        KConfigGroup cg(KSharedConfig::openConfig(), "KSharedConfigTest");
+        KConfigGroup cg(KSharedConfig::openConfig(KConfig::ConfigAssociation::KdeApp), "KSharedConfigTest");
         QCOMPARE(cg.readEntry("NumKey", 0), 1);
     }
 }
@@ -71,7 +71,7 @@ void KSharedConfigTest::testReadWriteSync()
 void KSharedConfigTest::testQrcFile()
 {
     QVERIFY(QFile::exists(QStringLiteral(":/testdata/test.ini")));
-    KSharedConfig::Ptr sharedConfig = KSharedConfig::openConfig(QStringLiteral(":/testdata/test.ini"), KConfig::NoGlobals);
+    KSharedConfig::Ptr sharedConfig = KSharedConfig::openConfig(KConfig::ConfigAssociation::KdeApp, QStringLiteral(":/testdata/test.ini"), KConfig::NoGlobals);
     QVERIFY(sharedConfig);
 
     KConfigGroup cfg(sharedConfig, QStringLiteral("MainSection"));

--- a/src/core/kauthorized.cpp
+++ b/src/core/kauthorized.cpp
@@ -182,7 +182,7 @@ public:
     {
         Q_ASSERT_X(QCoreApplication::instance(), "KAuthorizedPrivate()", "There has to be an existing QCoreApplication::instance() pointer");
 
-        KSharedConfig::Ptr config = KSharedConfig::openConfig();
+        KSharedConfig::Ptr config = KSharedConfig::openConfig(KConfig::ConfigAssociation::KdeApp);
 
         Q_ASSERT_X(config, "KAuthorizedPrivate()", "There has to be an existing KSharedConfig::openConfig() pointer");
         if (!config) {
@@ -216,7 +216,7 @@ bool KAuthorized::authorize(const QString &genericAction)
         return true;
     }
 
-    KConfigGroup cg(KSharedConfig::openConfig(), "KDE Action Restrictions");
+    KConfigGroup cg(KSharedConfig::openConfig(KConfig::ConfigAssociation::KdeApp), "KDE Action Restrictions");
     return cg.readEntry(genericAction, true);
 }
 
@@ -259,13 +259,13 @@ bool KAuthorized::authorizeControlModule(const QString &menuId)
     if (menuId.isEmpty() || kde_kiosk_exception) {
         return true;
     }
-    KConfigGroup cg(KSharedConfig::openConfig(), "KDE Control Module Restrictions");
+    KConfigGroup cg(KSharedConfig::openConfig(KConfig::ConfigAssociation::KdeApp), "KDE Control Module Restrictions");
     return cg.readEntry(menuId, true);
 }
 
 QStringList KAuthorized::authorizeControlModules(const QStringList &menuIds)
 {
-    KConfigGroup cg(KSharedConfig::openConfig(), "KDE Control Module Restrictions");
+    KConfigGroup cg(KSharedConfig::openConfig(KConfig::ConfigAssociation::KdeApp), "KDE Control Module Restrictions");
     QStringList result;
     for (const auto &id : menuIds) {
         if (cg.readEntry(id, true)) {
@@ -384,7 +384,7 @@ authorizeUrlActionInternal(const QString &action, const QUrl &_baseURL, const QU
 
     bool result = false;
     if (d->urlActionRestrictions.isEmpty()) {
-        KConfigGroup cg(KSharedConfig::openConfig(), "KDE URL Restrictions");
+        KConfigGroup cg(KSharedConfig::openConfig(KConfig::ConfigAssociation::KdeApp), "KDE URL Restrictions");
         loadUrlActionRestrictions(cg);
     }
 

--- a/src/core/kconfig.cpp
+++ b/src/core/kconfig.cpp
@@ -611,8 +611,8 @@ QString KConfig::mainConfigName()
     return appName + QLatin1String("rc");
 }
 
-
-std::optional<QString> getPrefix(KConfig::ConfigAssociation association) {
+std::optional<QString> getPrefix(KConfig::ConfigAssociation association)
+{
     switch (association) {
     case KConfig::ConfigAssociation::KdeApp:
         return std::make_optional(QString::fromUtf8("kde-app"));
@@ -621,13 +621,13 @@ std::optional<QString> getPrefix(KConfig::ConfigAssociation association) {
     case KConfig::ConfigAssociation::NoAssociation:
         return std::nullopt;
     default:
-        Q_ASSERT(false);  // report an error in debug builds, this switch should be exhaustive.
+        Q_ASSERT(false); // report an error in debug builds, this switch should be exhaustive.
         return std::nullopt;
     }
 }
 
-
-QString makeNewFileNameAndMigrate(const QString dir, std::optional<QString> prefix, const QString &fileName) {
+QString makeNewFileNameAndMigrate(const QString dir, std::optional<QString> prefix, const QString &fileName)
+{
     QString old = dir + QLatin1Char('/') + fileName;
     QString file = dir + QLatin1Char('/') + prefix.value_or(QString()) + fileName;
     if (QFileInfo::exists(old))

--- a/src/core/kconfig.h
+++ b/src/core/kconfig.h
@@ -136,12 +136,18 @@ public:
                      QStandardPaths::StandardLocation type = QStandardPaths::GenericConfigLocation);
 
     /**
-     * This is the old and deprecated constructor, please use KConfig(ConfigAssociation association, const QString &file = QString(), OpenFlags mode = FullConfig, QStandardPaths::StandardLocation type = QStandardPaths::GenericConfigLocation)
+     * This is the old and deprecated constructor, please use KConfig(ConfigAssociation association, const QString &file = QString(), OpenFlags mode =
+     * FullConfig, QStandardPaths::StandardLocation type = QStandardPaths::GenericConfigLocation)
      */
-    [[deprecated("This constructor is deprecated, please specify config association by calling KConfig(ConfigAssociation association, const QString &file = QString(), OpenFlags mode = FullConfig, QStandardPaths::StandardLocation type = QStandardPaths::GenericConfigLocation)" )]]
-    explicit KConfig(const QString &file = QString(),
-                     OpenFlags mode = FullConfig,
-                     QStandardPaths::StandardLocation type = QStandardPaths::GenericConfigLocation);
+    [[deprecated(
+        "This constructor is deprecated, please specify config association by calling KConfig(ConfigAssociation association, const QString &file = QString(), "
+        "OpenFlags mode = FullConfig, QStandardPaths::StandardLocation type = QStandardPaths::GenericConfigLocation)")]] explicit KConfig(const QString &file =
+                                                                                                                                              QString(),
+                                                                                                                                          OpenFlags mode =
+                                                                                                                                              FullConfig,
+                                                                                                                                          QStandardPaths::StandardLocation
+                                                                                                                                              type = QStandardPaths::
+                                                                                                                                                  GenericConfigLocation);
 
     /**
      * @internal

--- a/src/core/kconfig.h
+++ b/src/core/kconfig.h
@@ -94,6 +94,12 @@ public:
     Q_DECLARE_FLAGS(OpenFlags, OpenFlag)
 
     /**
+     * Describes which configuration family this configuration belongs to.
+     * This would determine the default location of the configuration file, if the file path is not absolute.
+     * It would make KConfig prepend kde-app and plasma, accordingly, to the configuration path.
+     */
+    enum class ConfigAssociation { NoAssociation, KdeApp, Plasma };
+    /**
      * Creates a KConfig object to manipulate a configuration file for the
      * current application.
      *
@@ -110,6 +116,9 @@ public:
      *
      * @note You probably want to use KSharedConfig::openConfig instead.
      *
+     * @param association  the config group associated with this config -
+     *                     is it a KDE application, or a Plasma component?
+     *
      * @param file         the name of the file. If an empty string is passed in
      *                     and SimpleConfig is passed in for the OpenFlags, then an in-memory
      *                     KConfig object is created which will not write out to file nor which
@@ -119,8 +128,17 @@ public:
      * @param type         The standard directory to look for the configuration
      *                     file in
      *
-     * @sa KSharedConfig::openConfig(const QString&, OpenFlags, QStandardPaths::StandardLocation)
+     * @sa KSharedConfig::openConfig(ConfigAssociation association, const QString&, OpenFlags, QStandardPaths::StandardLocation)
      */
+    explicit KConfig(ConfigAssociation association,
+                     const QString &file = QString(),
+                     OpenFlags mode = FullConfig,
+                     QStandardPaths::StandardLocation type = QStandardPaths::GenericConfigLocation);
+
+    /**
+     * This is the old and deprecated constructor, please use KConfig(ConfigAssociation association, const QString &file = QString(), OpenFlags mode = FullConfig, QStandardPaths::StandardLocation type = QStandardPaths::GenericConfigLocation)
+     */
+    [[deprecated("This constructor is deprecated, please specify config association by calling KConfig(ConfigAssociation association, const QString &file = QString(), OpenFlags mode = FullConfig, QStandardPaths::StandardLocation type = QStandardPaths::GenericConfigLocation)" )]]
     explicit KConfig(const QString &file = QString(),
                      OpenFlags mode = FullConfig,
                      QStandardPaths::StandardLocation type = QStandardPaths::GenericConfigLocation);
@@ -366,6 +384,8 @@ protected:
     KConfig(KConfigPrivate &d);
 
 private:
+    void _KConfig(const QString &file);
+
     friend class KConfigTest;
 
     QStringList keyList(const QString &aGroup = QString()) const;

--- a/src/core/kconfig_p.h
+++ b/src/core/kconfig_p.h
@@ -29,6 +29,7 @@ public:
     QStandardPaths::StandardLocation resourceType;
 
     void changeFileName(const QString &fileName);
+    void changeFileName(KConfig::ConfigAssociation association, const QString &fileName);
 
     // functions for KConfigGroup
     bool canWriteEntry(const QByteArray &group, const char *key, bool isDefault = false) const;
@@ -60,6 +61,7 @@ protected:
     QExplicitlySharedDataPointer<KConfigBackend> mBackend;
 
     KConfigPrivate(KConfig::OpenFlags flags, QStandardPaths::StandardLocation type);
+    KConfigPrivate(KConfig::ConfigAssociation association, KConfig::OpenFlags flags, QStandardPaths::StandardLocation type);
 
     virtual ~KConfigPrivate()
     {
@@ -83,6 +85,7 @@ private:
     QString fileName;
     QString etc_kderc;
     KConfigBase::AccessMode configState;
+    KConfig::ConfigAssociation association;
 
     bool wantGlobals() const
     {

--- a/src/core/kcoreconfigskeleton.cpp
+++ b/src/core/kcoreconfigskeleton.cpp
@@ -1113,6 +1113,14 @@ QVariant KCoreConfigSkeleton::ItemIntList::property() const
 }
 
 // static int kCoreConfigSkeletionDebugArea() { static int s_area = KDebug::registerArea("kdecore (KConfigSkeleton)"); return s_area; }
+KCoreConfigSkeleton::KCoreConfigSkeleton(KConfig::ConfigAssociation association, const QString &configname, QObject *parent)
+    : QObject(parent)
+    , d(new KCoreConfigSkeletonPrivate)
+{
+    // qDebug() << "Creating KCoreConfigSkeleton (" << (void *)this << ")";
+
+    d->mConfig = KSharedConfig::openConfig(association, configname, KConfig::FullConfig);
+}
 
 KCoreConfigSkeleton::KCoreConfigSkeleton(const QString &configname, QObject *parent)
     : QObject(parent)
@@ -1120,7 +1128,7 @@ KCoreConfigSkeleton::KCoreConfigSkeleton(const QString &configname, QObject *par
 {
     // qDebug() << "Creating KCoreConfigSkeleton (" << (void *)this << ")";
 
-    d->mConfig = KSharedConfig::openConfig(configname, KConfig::FullConfig);
+    d->mConfig = KSharedConfig::openConfig(KConfig::ConfigAssociation::NoAssociation, configname, KConfig::FullConfig);
 }
 
 KCoreConfigSkeleton::KCoreConfigSkeleton(KSharedConfig::Ptr pConfig, QObject *parent)

--- a/src/core/kcoreconfigskeleton.h
+++ b/src/core/kcoreconfigskeleton.h
@@ -1103,10 +1103,19 @@ public:
     /**
      * Constructor.
      *
+     * @param assoiation config association - is it a kde application, a plasma component, or neither?
+     *                   This will determine where the config file is saved, if the path given in name
+     *                   is empty or relative. It is ignored for absolute path.
      * @param configname name of config file. If no name is given, the default
      *                   config file as returned by KSharedConfig::openConfig() is used
      * @param parent the parent object (see QObject documentation)
      */
+    explicit KCoreConfigSkeleton(KConfig::ConfigAssociation association, const QString &configname = QString(), QObject *parent = nullptr);
+
+    /**
+     * This constructor is deprecated
+     */
+    [[deprecated("This constructor is deprecated, please specify association by calling KCoreConfigSkeleton(KConfig::ConfigAssociation association, const QString &configname = QString(), QObject *parent = nullptr)")]]
     explicit KCoreConfigSkeleton(const QString &configname = QString(), QObject *parent = nullptr);
 
     /**

--- a/src/core/kcoreconfigskeleton.h
+++ b/src/core/kcoreconfigskeleton.h
@@ -1115,8 +1115,9 @@ public:
     /**
      * This constructor is deprecated
      */
-    [[deprecated("This constructor is deprecated, please specify association by calling KCoreConfigSkeleton(KConfig::ConfigAssociation association, const QString &configname = QString(), QObject *parent = nullptr)")]]
-    explicit KCoreConfigSkeleton(const QString &configname = QString(), QObject *parent = nullptr);
+    [[deprecated(
+        "This constructor is deprecated, please specify association by calling KCoreConfigSkeleton(KConfig::ConfigAssociation association, const QString "
+        "&configname = QString(), QObject *parent = nullptr)")]] explicit KCoreConfigSkeleton(const QString &configname = QString(), QObject *parent = nullptr);
 
     /**
      * Constructor.

--- a/src/core/kdesktopfile.cpp
+++ b/src/core/kdesktopfile.cpp
@@ -33,7 +33,7 @@ public:
 };
 
 KDesktopFilePrivate::KDesktopFilePrivate(QStandardPaths::StandardLocation resourceType, const QString &fileName)
-    : KConfigPrivate(KConfig::NoGlobals, resourceType)
+    : KConfigPrivate(KConfig::ConfigAssociation::NoAssociation, KConfig::NoGlobals, resourceType)
 {
     mBackend = new KConfigIniBackend();
     bDynamicBackend = false;

--- a/src/core/ksharedconfig.cpp
+++ b/src/core/ksharedconfig.cpp
@@ -66,8 +66,8 @@ void _k_globalMainConfigSync()
     }
 }
 
-
-static void makeMainConfig(KSharedConfig::Ptr ptr) {
+static void makeMainConfig(KSharedConfig::Ptr ptr)
+{
     globalSharedConfig()->mainConfig = ptr;
     const bool isMainThread = !qApp || QThread::currentThread() == qApp->thread();
     static bool userWarned = false;
@@ -82,7 +82,8 @@ static void makeMainConfig(KSharedConfig::Ptr ptr) {
     }
 }
 
-std::optional<KSharedConfigPtr> KSharedConfig::tryGetGlobalConfig(const QString &fileName, OpenFlags flags, QStandardPaths::StandardLocation resType) {
+std::optional<KSharedConfigPtr> KSharedConfig::tryGetGlobalConfig(const QString &fileName, OpenFlags flags, QStandardPaths::StandardLocation resType)
+{
     GlobalSharedConfig *global = globalSharedConfig();
     if (!global->wasTestModeEnabled && QStandardPaths::isTestModeEnabled()) {
         global->wasTestModeEnabled = true;
@@ -100,8 +101,9 @@ std::optional<KSharedConfigPtr> KSharedConfig::tryGetGlobalConfig(const QString 
     return std::nullopt;
 }
 
-
-KSharedConfig::Ptr KSharedConfig::openConfig(KConfig::ConfigAssociation association, const QString &_fileName, OpenFlags flags, QStandardPaths::StandardLocation resType) {
+KSharedConfig::Ptr
+KSharedConfig::openConfig(KConfig::ConfigAssociation association, const QString &_fileName, OpenFlags flags, QStandardPaths::StandardLocation resType)
+{
     QString fileName(_fileName);
     if (fileName.isEmpty() && !flags.testFlag(KConfig::SimpleConfig)) {
         // Determine the config file name that KConfig will make up (see KConfigPrivate::changeFileName)
@@ -153,13 +155,11 @@ KSharedConfig::Ptr KSharedConfig::openStateConfig(const QString &_fileName)
     return openConfig(KConfig::ConfigAssociation::NoAssociation, fileName, SimpleConfig, QStandardPaths::AppDataLocation);
 }
 
-
 KSharedConfig::KSharedConfig(KConfig::ConfigAssociation association, const QString &fileName, OpenFlags flags, QStandardPaths::StandardLocation resType)
     : KConfig(association, fileName, flags, resType)
 {
     globalSharedConfig()->configList.append(this);
 }
-
 
 KSharedConfig::~KSharedConfig()
 {

--- a/src/core/ksharedconfig.h
+++ b/src/core/ksharedconfig.h
@@ -61,14 +61,18 @@ public:
      *
      * @sa KConfig
      */
-    static KSharedConfig::Ptr
-    openConfig(KConfig::ConfigAssociation association, const QString &fileName = QString(), OpenFlags mode = FullConfig, QStandardPaths::StandardLocation type = QStandardPaths::GenericConfigLocation);
+    static KSharedConfig::Ptr openConfig(KConfig::ConfigAssociation association,
+                                         const QString &fileName = QString(),
+                                         OpenFlags mode = FullConfig,
+                                         QStandardPaths::StandardLocation type = QStandardPaths::GenericConfigLocation);
 
     /**
-       This method is deprecated, please specify config association by calling openConfig(KConfig::ConfigAssociation association, const QString &fileName = QString(), OpenFlags mode = FullConfig, QStandardPaths::StandardLocation type = QStandardPaths::GenericConfigLocation);
+       This method is deprecated, please specify config association by calling openConfig(KConfig::ConfigAssociation association, const QString &fileName =
+       QString(), OpenFlags mode = FullConfig, QStandardPaths::StandardLocation type = QStandardPaths::GenericConfigLocation);
      */
-    [[deprecated("This method is deprecated, please specify config association by calling openConfig(KConfig::ConfigAssociation association, const QString &fileName = QString(), OpenFlags mode = FullConfig, QStandardPaths::StandardLocation type = QStandardPaths::GenericConfigLocation);")]]
-    static KSharedConfig::Ptr
+    [[deprecated(
+        "This method is deprecated, please specify config association by calling openConfig(KConfig::ConfigAssociation association, const QString &fileName = "
+        "QString(), OpenFlags mode = FullConfig, QStandardPaths::StandardLocation type = QStandardPaths::GenericConfigLocation);")]] static KSharedConfig::Ptr
     openConfig(const QString &fileName = QString(), OpenFlags mode = FullConfig, QStandardPaths::StandardLocation type = QStandardPaths::GenericConfigLocation);
 
     /**
@@ -102,7 +106,6 @@ private:
     static std::optional<KSharedConfig::Ptr> tryGetGlobalConfig(const QString &fileName, OpenFlags flags, QStandardPaths::StandardLocation resType);
 
     KSharedConfig(KConfig::ConfigAssociation association, const QString &file, OpenFlags mode, QStandardPaths::StandardLocation resourceType);
-
 };
 
 typedef KSharedConfig::Ptr KSharedConfigPtr;

--- a/src/core/ksharedconfig.h
+++ b/src/core/ksharedconfig.h
@@ -48,6 +48,9 @@ public:
      * to influence the values returned by this object.  See KConfig::OpenFlags for
      * more details.
      *
+     * @param association  the config group associated with this config -
+     *                     is it a KDE application, a Plasma component or neither?
+     *
      * @param fileName     the configuration file to open. If empty, it will be determined
      *                     automatically (from --config on the command line, otherwise
      *                     from the application name + "rc")
@@ -58,6 +61,13 @@ public:
      *
      * @sa KConfig
      */
+    static KSharedConfig::Ptr
+    openConfig(KConfig::ConfigAssociation association, const QString &fileName = QString(), OpenFlags mode = FullConfig, QStandardPaths::StandardLocation type = QStandardPaths::GenericConfigLocation);
+
+    /**
+       This method is deprecated, please specify config association by calling openConfig(KConfig::ConfigAssociation association, const QString &fileName = QString(), OpenFlags mode = FullConfig, QStandardPaths::StandardLocation type = QStandardPaths::GenericConfigLocation);
+     */
+    [[deprecated("This method is deprecated, please specify config association by calling openConfig(KConfig::ConfigAssociation association, const QString &fileName = QString(), OpenFlags mode = FullConfig, QStandardPaths::StandardLocation type = QStandardPaths::GenericConfigLocation);")]]
     static KSharedConfig::Ptr
     openConfig(const QString &fileName = QString(), OpenFlags mode = FullConfig, QStandardPaths::StandardLocation type = QStandardPaths::GenericConfigLocation);
 
@@ -89,8 +99,10 @@ private:
     Q_DISABLE_COPY(KSharedConfig)
     KConfigGroup groupImpl(const QByteArray &aGroup) override;
     const KConfigGroup groupImpl(const QByteArray &aGroup) const override;
+    static std::optional<KSharedConfig::Ptr> tryGetGlobalConfig(const QString &fileName, OpenFlags flags, QStandardPaths::StandardLocation resType);
 
-    KSharedConfig(const QString &file, OpenFlags mode, QStandardPaths::StandardLocation resourceType);
+    KSharedConfig(KConfig::ConfigAssociation association, const QString &file, OpenFlags mode, QStandardPaths::StandardLocation resourceType);
+
 };
 
 typedef KSharedConfig::Ptr KSharedConfigPtr;

--- a/src/gui/kconfigloader.cpp
+++ b/src/gui/kconfigloader.cpp
@@ -342,7 +342,11 @@ KConfigLoader::KConfigLoader(KSharedConfigPtr config, QIODevice *xml, QObject *p
 //       but KConfigSkeleton does not currently support this. it will eventually though,
 //       at which point this can be addressed properly
 KConfigLoader::KConfigLoader(const KConfigGroup &config, QIODevice *xml, QObject *parent)
-    : KConfigSkeleton(KSharedConfig::openConfig(KConfig::ConfigAssociation::NoAssociation, config.config()->name(), config.config()->openFlags(), config.config()->locationType()), parent)
+    : KConfigSkeleton(KSharedConfig::openConfig(KConfig::ConfigAssociation::NoAssociation,
+                                                config.config()->name(),
+                                                config.config()->openFlags(),
+                                                config.config()->locationType()),
+                      parent)
     , d(new ConfigLoaderPrivate)
 {
     setupConfigGroup(config, xml);
@@ -358,7 +362,8 @@ KConfigLoader::KConfigLoader(KConfig::ConfigAssociation association, const KConf
     setupConfigGroup(config, xml);
 }
 
-void KConfigLoader::setupConfigGroup(const KConfigGroup &config, QIODevice *xml) {
+void KConfigLoader::setupConfigGroup(const KConfigGroup &config, QIODevice *xml)
+{
     KConfigGroup group = config.parent();
     d->baseGroup = config.name();
     while (group.isValid() && group.name() != QLatin1String("<default>")) {
@@ -367,7 +372,6 @@ void KConfigLoader::setupConfigGroup(const KConfigGroup &config, QIODevice *xml)
     }
     d->parse(this, xml);
 }
-
 
 KConfigLoader::~KConfigLoader()
 {

--- a/src/gui/kconfigloader.h
+++ b/src/gui/kconfigloader.h
@@ -45,7 +45,7 @@ class ConfigLoaderPrivate;
  * \code
  * QDialog *dialog = new QDialog();
  * QFile xmlFile("path/to/kconfigxt.xml");
- * KConfigGroup cg = KSharedConfig::openConfig()->group(QString());
+ * KConfigGroup cg = KSharedConfig::openConfig(KConfig::ConfigAssociation::NoAssociation)->group(QString());
  * KConfigLoader *configLoader = new KConfigLoader(cg, &xmlFile, this);
  *
  * // load the ui file
@@ -92,10 +92,18 @@ public:
      * Creates a KConfigSkeleton populated using the definition found in
      * the XML data passed in.
      *
+     * @param association - is it a kde application, a plasma component, or neither?
+     *                This would determine the path the config file is located if configFile isn't an absolute path
      * @param configFile path to the configuration file to use
      * @param xml the xml data; must be valid KConfigXT data
      * @param parent optional QObject parent
      **/
+    KConfigLoader(KConfig::ConfigAssociation association, const QString &configFile, QIODevice *xml, QObject *parent = nullptr);
+
+    /**
+     * This constructor is deprecated.
+     */
+    [[deprecated("Please specify association by calling KConfigLoader(KConfig::ConfigAssociation association, const QString &configFile, QIODevice *xml, QObject *parent = nullptr)")]]
     KConfigLoader(const QString &configFile, QIODevice *xml, QObject *parent = nullptr);
 
     /**
@@ -112,10 +120,18 @@ public:
      * Creates a KConfigSkeleton populated using the definition found in
      * the XML data passed in.
      *
+     * @param association - is it a kde application, a plasma component, or neither?
+     *                This would determine the path the config file is located if configFile isn't an absolute path
      * @param config the group to use as the root for configuration items
      * @param xml the xml data; must be valid KConfigXT data
      * @param parent optional QObject parent
      **/
+    KConfigLoader(KConfig::ConfigAssociation associatoin, const KConfigGroup &config, QIODevice *xml, QObject *parent = nullptr);
+
+    /**
+     * deprecated constructor
+     **/
+    [[deprecated("Please specify association by calling KConfigLoader(KConfig::ConfigAssociation associatoin, const KConfigGroup &config, QIODevice *xml, QObject *parent = nullptr) instead.")]]
     KConfigLoader(const KConfigGroup &config, QIODevice *xml, QObject *parent = nullptr);
 
     ~KConfigLoader() override;
@@ -157,6 +173,7 @@ protected:
 
 private:
     ConfigLoaderPrivate *const d;
+    void setupConfigGroup(const KConfigGroup &config, QIODevice *xml);
 };
 
 #endif // multiple inclusion guard

--- a/src/gui/kconfigloader.h
+++ b/src/gui/kconfigloader.h
@@ -103,8 +103,9 @@ public:
     /**
      * This constructor is deprecated.
      */
-    [[deprecated("Please specify association by calling KConfigLoader(KConfig::ConfigAssociation association, const QString &configFile, QIODevice *xml, QObject *parent = nullptr)")]]
-    KConfigLoader(const QString &configFile, QIODevice *xml, QObject *parent = nullptr);
+    [[deprecated(
+        "Please specify association by calling KConfigLoader(KConfig::ConfigAssociation association, const QString &configFile, QIODevice *xml, QObject "
+        "*parent = nullptr)")]] KConfigLoader(const QString &configFile, QIODevice *xml, QObject *parent = nullptr);
 
     /**
      * Creates a KConfigSkeleton populated using the definition found in
@@ -131,8 +132,9 @@ public:
     /**
      * deprecated constructor
      **/
-    [[deprecated("Please specify association by calling KConfigLoader(KConfig::ConfigAssociation associatoin, const KConfigGroup &config, QIODevice *xml, QObject *parent = nullptr) instead.")]]
-    KConfigLoader(const KConfigGroup &config, QIODevice *xml, QObject *parent = nullptr);
+    [[deprecated(
+        "Please specify association by calling KConfigLoader(KConfig::ConfigAssociation associatoin, const KConfigGroup &config, QIODevice *xml, QObject "
+        "*parent = nullptr) instead.")]] KConfigLoader(const KConfigGroup &config, QIODevice *xml, QObject *parent = nullptr);
 
     ~KConfigLoader() override;
 

--- a/src/gui/kconfigskeleton.cpp
+++ b/src/gui/kconfigskeleton.cpp
@@ -10,8 +10,13 @@
 
 #include <kcoreconfigskeleton_p.h>
 
+KConfigSkeleton::KConfigSkeleton(KConfig::ConfigAssociation association, const QString &configname, QObject *parent)
+    : KCoreConfigSkeleton(association, configname, parent)
+{
+}
+
 KConfigSkeleton::KConfigSkeleton(const QString &configname, QObject *parent)
-    : KCoreConfigSkeleton(configname, parent)
+    : KCoreConfigSkeleton(KConfig::ConfigAssociation::NoAssociation, configname, parent)
 {
 }
 

--- a/src/gui/kconfigskeleton.h
+++ b/src/gui/kconfigskeleton.h
@@ -75,12 +75,18 @@ public:
 public:
     /**
      * Constructor.
-     *
+     * @param association - is it a kde application, a plasma component or neither?
+     *                      This determines where the config file is looked for unless configname is an absolute path.
      * @param configname name of config file. If no name is given, the default
      * config file as returned by KSharedConfig::openConfig() is used.
      */
-    explicit KConfigSkeleton(const QString &configname = QString(), QObject *parent = nullptr);
+    explicit KConfigSkeleton(KConfig::ConfigAssociation association, const QString &configname = QString(), QObject *parent = nullptr);
 
+    /**
+     * This constructor is deprecated.
+     */
+    [[deprecated("Please specify association by calling KConfigSkeleton(KConfig::ConfigAssociation association, const QString &configname = QString(), QObject *parent = nullptr) instead.")]]
+    explicit KConfigSkeleton(const QString &configname = QString(), QObject *parent = nullptr);
     /**
      * Constructor.
      *

--- a/src/gui/kconfigskeleton.h
+++ b/src/gui/kconfigskeleton.h
@@ -85,8 +85,9 @@ public:
     /**
      * This constructor is deprecated.
      */
-    [[deprecated("Please specify association by calling KConfigSkeleton(KConfig::ConfigAssociation association, const QString &configname = QString(), QObject *parent = nullptr) instead.")]]
-    explicit KConfigSkeleton(const QString &configname = QString(), QObject *parent = nullptr);
+    [[deprecated(
+        "Please specify association by calling KConfigSkeleton(KConfig::ConfigAssociation association, const QString &configname = QString(), QObject *parent "
+        "= nullptr) instead.")]] explicit KConfigSkeleton(const QString &configname = QString(), QObject *parent = nullptr);
     /**
      * Constructor.
      *


### PR DESCRIPTION
Fixes [issue 422529](https://bugs.kde.org/show_bug.cgi?id=422529):

The problem with the current situation is that KDE configuration files are all written to the base of the standard config path, and it makes it difficult to determine which ones are in need of backing up \ purging if we want to clean plasma settings independently of KDE app settings, or KDE settings independently of other app settings.

The suggested fix is to require users of KConfig to specify the association of their app - is it a kde application, a plasma component, or "other".

I've added a KConfig::ConfigAssociation enum, which determines where this config belongs.
Currently, there are 3 associations: 
1. NoAssociation retains the current behaviour, where the config file is written directly under the standard config path.
2. Plasma indicates this is a plasma component and should be saved under a sub-directory called plasma
3. KdeApp indicates this is a KDE application, and should be saved under a sub-directory called kde-app

The bulk of the logic resides in KConfig.cpp, under the new functions makeNewFileNameAndMigrate and getPrefix.
KSharedConfig.cpp also got refactored to share code between the deprecated and new openConfig function.
The only non-trivial decision I've made so far was to decide that state config should be saved with no association, as they don't require backing up or restoring. But we may want to create a "state" prefix for these.

There are several open issues:

1. How do we want to associate keyboard shortcut settings? Do we keep them outside, in kde-app, in plasma, or should we have a third category?

2. Will KConfigGui be exclusively used by kde applications, so we can write it to kde-app? or do we need to also deprecate its default constructor and require association?

3. Do you agree the KEmailSettings should be save to kde-app?

4. Where do we want kconf_updaterc to reside? (used by KonfUpdate (also, this name seems like a spelling error, it should probably have been KConfUpdate...)

5. There are also kreadconfig and kwriteconfig command line utilities which should probably get additional optional flag for association, and default to no association.

6. I wasn't able to fix all the tests to use the new interface, since I'm not familiar with the autotests framework.

I thought this is a big enough change to begin a merge, and take care of the other issues in a different pull request to make this one easier to follow, since it doesn't break anything yet except producing deprecation warnings, but I'm open to iteratively fix the above issues in this PR as well.